### PR TITLE
✨ Feature: Hashtag, FeedToHashtag Entity 정의

### DIFF
--- a/src/main/java/com/wanted/feed/feed/domain/Feed.java
+++ b/src/main/java/com/wanted/feed/feed/domain/Feed.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Feed {
+
     @Id
     @GeneratedValue
     private Long id;
@@ -33,6 +34,7 @@ public class Feed {
         this.type = type;
         this.title = title;
         this.content = content;
+        this.viewCount = 0;
         this.contentId = contentId;
     }
 }

--- a/src/main/java/com/wanted/feed/feed/domain/FeedToHashtag.java
+++ b/src/main/java/com/wanted/feed/feed/domain/FeedToHashtag.java
@@ -1,0 +1,25 @@
+package com.wanted.feed.feed.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "feeds_hashtags")
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class FeedToHashtag {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column(name = "feed_id")
+    private Long feedId;
+
+    @Column(name = "hashtag_id")
+    private Long hashtagId;
+}

--- a/src/main/java/com/wanted/feed/feed/domain/Hashtag.java
+++ b/src/main/java/com/wanted/feed/feed/domain/Hashtag.java
@@ -1,0 +1,22 @@
+package com.wanted.feed.feed.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "hashtags")
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class Hashtag {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+}


### PR DESCRIPTION
## 💻 작업 내역 
### ✓ `Hashtag`, `FeedToHashtag` Entity 정의

- `FeedToHashtag`
Feed와 Hashtag 간의 상호 참조 관계를 알 수 있습니다.

### ✓ `Feed` Entity 생성자에서 viewCount 초기값을 0으로 할당

## 🔎 PR 특이 사항
- `FeedToHashtag` Entity가 Feed, Hashtag Entity를 직접 참조하도록 `@ManyToOne`을 부여하는 것을 고려하였으나, 일단 Column 값만을 직접 연결했습니다.
- 구현 과정에서 간접/직접 참조 여부를 결정할 계획입니다.