### PR TITLE
✨ Feature: 피드 좋아요 기능 수정

### DIFF
--- a/src/main/java/com/wanted/feed/feed/controller/FeedLikeController.java
+++ b/src/main/java/com/wanted/feed/feed/controller/FeedLikeController.java
@@ -6,6 +6,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "피드")
@@ -20,8 +22,10 @@ public class FeedLikeController {
 
     @Operation(description = "피드 좋아요 요청")
     @PostMapping("/feeds/{id}/like")
-    public ApiResponse<Void> likeFeed(@PathVariable Long id) {
-        feedLikeService.sendFeedLike(1L, id);
+    public ApiResponse<Void> likeFeed(
+            @RequestAttribute("userId") Long userId,
+            @PathVariable Long id) {
+        feedLikeService.sendFeedLike(userId, id);
         return ApiResponse.ok();
     }
 }

--- a/src/main/java/com/wanted/feed/feed/controller/FeedLikeController.java
+++ b/src/main/java/com/wanted/feed/feed/controller/FeedLikeController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "feed-like", description = "피드 좋아요 API")
+@Tag(name = "피드")
 @RestController
 public class FeedLikeController {
 
@@ -18,8 +18,8 @@ public class FeedLikeController {
         this.feedLikeService = feedLikeService;
     }
 
-    @PostMapping("/feeds/{id}/like")
     @Operation(description = "피드 좋아요 요청")
+    @PostMapping("/feeds/{id}/like")
     public ApiResponse<Void> likeFeed(@PathVariable Long id) {
         feedLikeService.sendFeedLike(1L, id);
         return ApiResponse.ok();

--- a/src/main/java/com/wanted/feed/feed/service/FeedLikeService.java
+++ b/src/main/java/com/wanted/feed/feed/service/FeedLikeService.java
@@ -31,10 +31,17 @@ public class FeedLikeService {
     public void sendFeedLike(Long userId, Long feedId) {
         Feed feed = findFeed(feedId);
         SnsClient client = snsClientHandler.getSnsClientByFeed(feed);
+
         ResponseEntity<String> response = client.likeFeed(feed.getContentId());
         if (isFail(response)) {
             throw new SnsLikeFeedFailException();
         }
+
+        feed.updateLikes();
+        saveLike(userId, feedId);
+    }
+
+    private void saveLike(Long userId, Long feedId) {
         Like like = createLike(userId, feedId);
         likeRepository.save(like);
     }

--- a/src/test/java/com/wanted/feed/feed/service/FeedLikeServiceTest.java
+++ b/src/test/java/com/wanted/feed/feed/service/FeedLikeServiceTest.java
@@ -1,5 +1,6 @@
 package com.wanted.feed.feed.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -69,6 +70,7 @@ class FeedLikeServiceTest {
         feedLikeService.sendFeedLike(1L, 1L);
 
         // then
+        assertThat(feed.getLikeCount()).isEqualTo(1L);
         verify(likeRepository, times(1)).save(any(Like.class));
     }
 
@@ -83,6 +85,7 @@ class FeedLikeServiceTest {
 
 
         // when, then
+        assertThat(feed.getLikeCount()).isEqualTo(0L);
         assertThatThrownBy(() -> feedLikeService.sendFeedLike(1L, 1L))
                 .isInstanceOf(SnsLikeFeedFailException.class);
     }


### PR DESCRIPTION
## 💻 작업 내역 
### ✓ 피드 좋아요 기능 수정 bf5f60fc53105df142b6bcc688dd61aad8f1e5f7

1. 피드 번호로 피드 조회
2. 피드에 있는 SNS 에 종류에 따라 좋아요 요청을 처리할 수 있는 적절한 SnsClient 찾기
3. 외부 SNS에 좋아요 요청
4. ➕ 피드 좋아요 카운트 수 1 증가
5. 피드 좋아요 저장

기존 하드 코딩 -> 인증된 유저 `userId` 받도록 수정

### ✓ Swagger 태그 추가 cf14fc6e19e4a34f1ebec53563cdbdadc99b55ee

참조 : #8 