### PR TITLE
♻️ Refactor: 예외 패키지 리팩토링

### DIFF
--- a/src/main/java/com/wanted/feed/common/JwtFilter.java
+++ b/src/main/java/com/wanted/feed/common/JwtFilter.java
@@ -2,14 +2,9 @@ package com.wanted.feed.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wanted.feed.common.util.TokenProvider;
-import com.wanted.feed.exception.ErrorResponse;
-import com.wanted.feed.exception.ErrorType;
-import com.wanted.feed.exception.WantedException;
+import com.wanted.feed.common.exception.ErrorResponse;
+import com.wanted.feed.common.exception.ErrorType;
 import com.wanted.feed.user.domain.UserRepository;
-import com.wanted.feed.user.exception.ExpiredTokenException;
-import com.wanted.feed.user.exception.InvalidTokenException;
-import com.wanted.feed.user.exception.InvalidTypeOfTokenException;
-import com.wanted.feed.user.exception.NullTokenException;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/src/main/java/com/wanted/feed/common/exception/ErrorResponse.java
+++ b/src/main/java/com/wanted/feed/common/exception/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.wanted.feed.exception;
+package com.wanted.feed.common.exception;
 
 
 public record ErrorResponse(

--- a/src/main/java/com/wanted/feed/common/exception/ErrorType.java
+++ b/src/main/java/com/wanted/feed/common/exception/ErrorType.java
@@ -1,13 +1,13 @@
-package com.wanted.feed.exception;
+package com.wanted.feed.common.exception;
 
-import com.wanted.feed.exception.client.SnsShareFeedFailException;
+import com.wanted.feed.feign.exception.SnsShareFeedFailException;
 import com.wanted.feed.feed.exception.FeedNotFoundException;
 import com.wanted.feed.user.exception.ApprovedUserException;
-import com.wanted.feed.exception.client.SnsContentIdNotNullException;
-import com.wanted.feed.exception.client.SnsLikeFeedFailException;
-import com.wanted.feed.exception.client.SnsNotSupportException;
-import com.wanted.feed.exception.feed.like.LikeFeedIdNotNullException;
-import com.wanted.feed.exception.feed.like.LikeUserIdNotNullException;
+import com.wanted.feed.feign.exception.SnsContentIdNotNullException;
+import com.wanted.feed.feign.exception.SnsLikeFeedFailException;
+import com.wanted.feed.feign.exception.SnsNotSupportException;
+import com.wanted.feed.feed.exception.like.LikeFeedIdNotNullException;
+import com.wanted.feed.feed.exception.like.LikeUserIdNotNullException;
 import com.wanted.feed.feed.exception.share.ShareFeedIdNotNullException;
 import com.wanted.feed.feed.exception.share.ShareUserIdNotNullException;
 import com.wanted.feed.user.exception.DuplicateUserException;

--- a/src/main/java/com/wanted/feed/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/wanted/feed/common/exception/GlobalControllerAdvice.java
@@ -1,4 +1,4 @@
-package com.wanted.feed.exception;
+package com.wanted.feed.common.exception;
 
 import java.util.StringJoiner;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/wanted/feed/common/exception/WantedException.java
+++ b/src/main/java/com/wanted/feed/common/exception/WantedException.java
@@ -1,4 +1,4 @@
-package com.wanted.feed.exception;
+package com.wanted.feed.common.exception;
 
 import lombok.Getter;
 

--- a/src/main/java/com/wanted/feed/exception/client/SnsContentIdNotNullException.java
+++ b/src/main/java/com/wanted/feed/exception/client/SnsContentIdNotNullException.java
@@ -1,7 +1,0 @@
-package com.wanted.feed.exception.client;
-
-import com.wanted.feed.exception.WantedException;
-
-public class SnsContentIdNotNullException extends WantedException {
-
-}

--- a/src/main/java/com/wanted/feed/exception/client/SnsLikeFeedFailException.java
+++ b/src/main/java/com/wanted/feed/exception/client/SnsLikeFeedFailException.java
@@ -1,7 +1,0 @@
-package com.wanted.feed.exception.client;
-
-import com.wanted.feed.exception.WantedException;
-
-public class SnsLikeFeedFailException extends WantedException {
-
-}

--- a/src/main/java/com/wanted/feed/exception/client/SnsNotSupportException.java
+++ b/src/main/java/com/wanted/feed/exception/client/SnsNotSupportException.java
@@ -1,7 +1,0 @@
-package com.wanted.feed.exception.client;
-
-import com.wanted.feed.exception.WantedException;
-
-public class SnsNotSupportException extends WantedException {
-
-}

--- a/src/main/java/com/wanted/feed/exception/client/SnsShareFeedFailException.java
+++ b/src/main/java/com/wanted/feed/exception/client/SnsShareFeedFailException.java
@@ -1,7 +1,0 @@
-package com.wanted.feed.exception.client;
-
-import com.wanted.feed.exception.WantedException;
-
-public class SnsShareFeedFailException extends WantedException {
-
-}

--- a/src/main/java/com/wanted/feed/exception/feed/like/LikeFeedIdNotNullException.java
+++ b/src/main/java/com/wanted/feed/exception/feed/like/LikeFeedIdNotNullException.java
@@ -1,6 +1,0 @@
-package com.wanted.feed.exception.feed.like;
-
-import com.wanted.feed.exception.WantedException;
-
-public class LikeFeedIdNotNullException extends WantedException {
-}

--- a/src/main/java/com/wanted/feed/exception/feed/like/LikeUserIdNotNullException.java
+++ b/src/main/java/com/wanted/feed/exception/feed/like/LikeUserIdNotNullException.java
@@ -1,6 +1,0 @@
-package com.wanted.feed.exception.feed.like;
-
-import com.wanted.feed.exception.WantedException;
-
-public class LikeUserIdNotNullException extends WantedException {
-}

--- a/src/main/java/com/wanted/feed/feed/domain/Like.java
+++ b/src/main/java/com/wanted/feed/feed/domain/Like.java
@@ -1,7 +1,7 @@
 package com.wanted.feed.feed.domain;
 
-import com.wanted.feed.exception.feed.like.LikeFeedIdNotNullException;
-import com.wanted.feed.exception.feed.like.LikeUserIdNotNullException;
+import com.wanted.feed.feed.exception.like.LikeFeedIdNotNullException;
+import com.wanted.feed.feed.exception.like.LikeUserIdNotNullException;
 import com.wanted.feed.feed.domain.vo.FeedId;
 import com.wanted.feed.feed.domain.vo.UserId;
 import jakarta.persistence.Embedded;

--- a/src/main/java/com/wanted/feed/feed/domain/vo/FeedId.java
+++ b/src/main/java/com/wanted/feed/feed/domain/vo/FeedId.java
@@ -1,6 +1,6 @@
 package com.wanted.feed.feed.domain.vo;
 
-import com.wanted.feed.exception.feed.like.LikeFeedIdNotNullException;
+import com.wanted.feed.feed.exception.like.LikeFeedIdNotNullException;
 import jakarta.persistence.Embeddable;
 import java.util.Objects;
 import lombok.AccessLevel;

--- a/src/main/java/com/wanted/feed/feed/domain/vo/UserId.java
+++ b/src/main/java/com/wanted/feed/feed/domain/vo/UserId.java
@@ -1,6 +1,6 @@
 package com.wanted.feed.feed.domain.vo;
 
-import com.wanted.feed.exception.feed.like.LikeUserIdNotNullException;
+import com.wanted.feed.feed.exception.like.LikeUserIdNotNullException;
 import jakarta.persistence.Embeddable;
 import java.util.Objects;
 import lombok.AccessLevel;

--- a/src/main/java/com/wanted/feed/feed/exception/FeedNotFoundException.java
+++ b/src/main/java/com/wanted/feed/feed/exception/FeedNotFoundException.java
@@ -1,6 +1,6 @@
 package com.wanted.feed.feed.exception;
 
-import com.wanted.feed.exception.WantedException;
+import com.wanted.feed.common.exception.WantedException;
 
 public class FeedNotFoundException extends WantedException {
 }

--- a/src/main/java/com/wanted/feed/feed/exception/like/LikeFeedIdNotNullException.java
+++ b/src/main/java/com/wanted/feed/feed/exception/like/LikeFeedIdNotNullException.java
@@ -1,0 +1,6 @@
+package com.wanted.feed.feed.exception.like;
+
+import com.wanted.feed.common.exception.WantedException;
+
+public class LikeFeedIdNotNullException extends WantedException {
+}

--- a/src/main/java/com/wanted/feed/feed/exception/like/LikeUserIdNotNullException.java
+++ b/src/main/java/com/wanted/feed/feed/exception/like/LikeUserIdNotNullException.java
@@ -1,0 +1,6 @@
+package com.wanted.feed.feed.exception.like;
+
+import com.wanted.feed.common.exception.WantedException;
+
+public class LikeUserIdNotNullException extends WantedException {
+}

--- a/src/main/java/com/wanted/feed/feed/exception/share/ShareFeedIdNotNullException.java
+++ b/src/main/java/com/wanted/feed/feed/exception/share/ShareFeedIdNotNullException.java
@@ -1,6 +1,6 @@
 package com.wanted.feed.feed.exception.share;
 
-import com.wanted.feed.exception.WantedException;
+import com.wanted.feed.common.exception.WantedException;
 
 public class ShareFeedIdNotNullException extends WantedException {
 

--- a/src/main/java/com/wanted/feed/feed/exception/share/ShareUserIdNotNullException.java
+++ b/src/main/java/com/wanted/feed/feed/exception/share/ShareUserIdNotNullException.java
@@ -1,6 +1,6 @@
 package com.wanted.feed.feed.exception.share;
 
-import com.wanted.feed.exception.WantedException;
+import com.wanted.feed.common.exception.WantedException;
 
 public class ShareUserIdNotNullException extends WantedException {
 

--- a/src/main/java/com/wanted/feed/feed/service/FeedLikeService.java
+++ b/src/main/java/com/wanted/feed/feed/service/FeedLikeService.java
@@ -1,6 +1,6 @@
 package com.wanted.feed.feed.service;
 
-import com.wanted.feed.exception.client.SnsLikeFeedFailException;
+import com.wanted.feed.feign.exception.SnsLikeFeedFailException;
 import com.wanted.feed.feed.domain.Feed;
 import com.wanted.feed.feed.domain.FeedRepository;
 import com.wanted.feed.feed.domain.Like;

--- a/src/main/java/com/wanted/feed/feed/service/FeedShareService.java
+++ b/src/main/java/com/wanted/feed/feed/service/FeedShareService.java
@@ -1,6 +1,6 @@
 package com.wanted.feed.feed.service;
 
-import com.wanted.feed.exception.client.SnsShareFeedFailException;
+import com.wanted.feed.feign.exception.SnsShareFeedFailException;
 import com.wanted.feed.feed.domain.Feed;
 import com.wanted.feed.feed.domain.FeedRepository;
 import com.wanted.feed.feed.domain.Share;

--- a/src/main/java/com/wanted/feed/feign/SnsClient.java
+++ b/src/main/java/com/wanted/feed/feign/SnsClient.java
@@ -1,6 +1,6 @@
 package com.wanted.feed.feign;
 
-import com.wanted.feed.exception.client.SnsContentIdNotNullException;
+import com.wanted.feed.feign.exception.SnsContentIdNotNullException;
 import com.wanted.feed.feign.dto.response.ClientShareResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/com/wanted/feed/feign/SnsType.java
+++ b/src/main/java/com/wanted/feed/feign/SnsType.java
@@ -1,6 +1,6 @@
 package com.wanted.feed.feign;
 
-import com.wanted.feed.exception.client.SnsNotSupportException;
+import com.wanted.feed.feign.exception.SnsNotSupportException;
 import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/wanted/feed/feign/exception/SnsContentIdNotNullException.java
+++ b/src/main/java/com/wanted/feed/feign/exception/SnsContentIdNotNullException.java
@@ -1,0 +1,7 @@
+package com.wanted.feed.feign.exception;
+
+import com.wanted.feed.common.exception.WantedException;
+
+public class SnsContentIdNotNullException extends WantedException {
+
+}

--- a/src/main/java/com/wanted/feed/feign/exception/SnsLikeFeedFailException.java
+++ b/src/main/java/com/wanted/feed/feign/exception/SnsLikeFeedFailException.java
@@ -1,0 +1,7 @@
+package com.wanted.feed.feign.exception;
+
+import com.wanted.feed.common.exception.WantedException;
+
+public class SnsLikeFeedFailException extends WantedException {
+
+}

--- a/src/main/java/com/wanted/feed/feign/exception/SnsNotSupportException.java
+++ b/src/main/java/com/wanted/feed/feign/exception/SnsNotSupportException.java
@@ -1,0 +1,7 @@
+package com.wanted.feed.feign.exception;
+
+import com.wanted.feed.common.exception.WantedException;
+
+public class SnsNotSupportException extends WantedException {
+
+}

--- a/src/main/java/com/wanted/feed/feign/exception/SnsShareFeedFailException.java
+++ b/src/main/java/com/wanted/feed/feign/exception/SnsShareFeedFailException.java
@@ -1,0 +1,7 @@
+package com.wanted.feed.feign.exception;
+
+import com.wanted.feed.common.exception.WantedException;
+
+public class SnsShareFeedFailException extends WantedException {
+
+}

--- a/src/main/java/com/wanted/feed/feign/handler/SnsClientHandler.java
+++ b/src/main/java/com/wanted/feed/feign/handler/SnsClientHandler.java
@@ -1,6 +1,6 @@
 package com.wanted.feed.feign.handler;
 
-import com.wanted.feed.exception.client.SnsNotSupportException;
+import com.wanted.feed.feign.exception.SnsNotSupportException;
 import com.wanted.feed.feed.domain.Feed;
 import com.wanted.feed.feign.SnsType;
 import com.wanted.feed.feign.SnsClient;

--- a/src/main/java/com/wanted/feed/user/exception/ApprovedUserException.java
+++ b/src/main/java/com/wanted/feed/user/exception/ApprovedUserException.java
@@ -1,6 +1,6 @@
 package com.wanted.feed.user.exception;
 
-import com.wanted.feed.exception.WantedException;
+import com.wanted.feed.common.exception.WantedException;
 
 public class ApprovedUserException extends WantedException {
 }

--- a/src/main/java/com/wanted/feed/user/exception/DuplicateUserException.java
+++ b/src/main/java/com/wanted/feed/user/exception/DuplicateUserException.java
@@ -1,6 +1,6 @@
 package com.wanted.feed.user.exception;
 
-import com.wanted.feed.exception.WantedException;
+import com.wanted.feed.common.exception.WantedException;
 
 public class DuplicateUserException extends WantedException {
 }

--- a/src/main/java/com/wanted/feed/user/exception/ExpiredTokenException.java
+++ b/src/main/java/com/wanted/feed/user/exception/ExpiredTokenException.java
@@ -1,5 +1,5 @@
 package com.wanted.feed.user.exception;
 
-import com.wanted.feed.exception.WantedException;
+import com.wanted.feed.common.exception.WantedException;
 
 public class ExpiredTokenException extends WantedException {}

--- a/src/main/java/com/wanted/feed/user/exception/InvalidTokenException.java
+++ b/src/main/java/com/wanted/feed/user/exception/InvalidTokenException.java
@@ -1,5 +1,5 @@
 package com.wanted.feed.user.exception;
 
-import com.wanted.feed.exception.WantedException;
+import com.wanted.feed.common.exception.WantedException;
 
 public class InvalidTokenException extends WantedException {}

--- a/src/main/java/com/wanted/feed/user/exception/InvalidTypeOfTokenException.java
+++ b/src/main/java/com/wanted/feed/user/exception/InvalidTypeOfTokenException.java
@@ -1,5 +1,5 @@
 package com.wanted.feed.user.exception;
 
-import com.wanted.feed.exception.WantedException;
+import com.wanted.feed.common.exception.WantedException;
 
 public class InvalidTypeOfTokenException extends WantedException {}

--- a/src/main/java/com/wanted/feed/user/exception/MismatchAuthCodeException.java
+++ b/src/main/java/com/wanted/feed/user/exception/MismatchAuthCodeException.java
@@ -1,6 +1,6 @@
 package com.wanted.feed.user.exception;
 
-import com.wanted.feed.exception.WantedException;
+import com.wanted.feed.common.exception.WantedException;
 
 public class MismatchAuthCodeException extends WantedException {
 }

--- a/src/main/java/com/wanted/feed/user/exception/MismatchPasswordException.java
+++ b/src/main/java/com/wanted/feed/user/exception/MismatchPasswordException.java
@@ -1,6 +1,6 @@
 package com.wanted.feed.user.exception;
 
-import com.wanted.feed.exception.WantedException;
+import com.wanted.feed.common.exception.WantedException;
 
 public class MismatchPasswordException extends WantedException {
 }

--- a/src/main/java/com/wanted/feed/user/exception/NotFoundAuthCodeException.java
+++ b/src/main/java/com/wanted/feed/user/exception/NotFoundAuthCodeException.java
@@ -1,6 +1,6 @@
 package com.wanted.feed.user.exception;
 
-import com.wanted.feed.exception.WantedException;
+import com.wanted.feed.common.exception.WantedException;
 
 public class NotFoundAuthCodeException extends WantedException {
 }

--- a/src/main/java/com/wanted/feed/user/exception/NotFoundUserException.java
+++ b/src/main/java/com/wanted/feed/user/exception/NotFoundUserException.java
@@ -1,6 +1,6 @@
 package com.wanted.feed.user.exception;
 
-import com.wanted.feed.exception.WantedException;
+import com.wanted.feed.common.exception.WantedException;
 
 public class NotFoundUserException extends WantedException {
 }

--- a/src/main/java/com/wanted/feed/user/exception/NullTokenException.java
+++ b/src/main/java/com/wanted/feed/user/exception/NullTokenException.java
@@ -1,5 +1,5 @@
 package com.wanted.feed.user.exception;
 
-import com.wanted.feed.exception.WantedException;
+import com.wanted.feed.common.exception.WantedException;
 
 public class NullTokenException extends WantedException {}

--- a/src/main/java/com/wanted/feed/user/service/JoinService.java
+++ b/src/main/java/com/wanted/feed/user/service/JoinService.java
@@ -1,6 +1,6 @@
 package com.wanted.feed.user.service;
 
-import com.wanted.feed.exception.WantedException;
+import com.wanted.feed.common.exception.WantedException;
 import com.wanted.feed.user.domain.AuthCode;
 import com.wanted.feed.user.domain.AuthCodeRepository;
 import com.wanted.feed.user.domain.User;

--- a/src/test/java/com/wanted/feed/common/JwtFilterTest.java
+++ b/src/test/java/com/wanted/feed/common/JwtFilterTest.java
@@ -5,7 +5,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import com.wanted.feed.common.response.JwtResponse;
 import com.wanted.feed.common.util.TokenProvider;
-import com.wanted.feed.exception.ErrorType;
+import com.wanted.feed.common.exception.ErrorType;
 import com.wanted.feed.user.domain.User;
 import com.wanted.feed.user.domain.UserRepository;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/wanted/feed/feed/domain/LikeTest.java
+++ b/src/test/java/com/wanted/feed/feed/domain/LikeTest.java
@@ -3,8 +3,8 @@ package com.wanted.feed.feed.domain;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.wanted.feed.exception.feed.like.LikeFeedIdNotNullException;
-import com.wanted.feed.exception.feed.like.LikeUserIdNotNullException;
+import com.wanted.feed.feed.exception.like.LikeFeedIdNotNullException;
+import com.wanted.feed.feed.exception.like.LikeUserIdNotNullException;
 import com.wanted.feed.feed.domain.vo.FeedId;
 import com.wanted.feed.feed.domain.vo.UserId;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/wanted/feed/feed/service/FeedLikeServiceTest.java
+++ b/src/test/java/com/wanted/feed/feed/service/FeedLikeServiceTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.wanted.feed.exception.client.SnsLikeFeedFailException;
+import com.wanted.feed.feign.exception.SnsLikeFeedFailException;
 import com.wanted.feed.feed.domain.Feed;
 import com.wanted.feed.feed.domain.FeedRepository;
 import com.wanted.feed.feed.domain.Like;

--- a/src/test/java/com/wanted/feed/feed/service/FeedServiceTest.java
+++ b/src/test/java/com/wanted/feed/feed/service/FeedServiceTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 
-import com.wanted.feed.exception.ErrorType;
+import com.wanted.feed.common.exception.ErrorType;
 import com.wanted.feed.feed.domain.Feed;
 import com.wanted.feed.feed.domain.FeedRepository;
 import com.wanted.feed.feed.dto.FeedDetailResponseDto;

--- a/src/test/java/com/wanted/feed/feed/service/FeedShareServiceTest.java
+++ b/src/test/java/com/wanted/feed/feed/service/FeedShareServiceTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.wanted.feed.exception.client.SnsShareFeedFailException;
+import com.wanted.feed.feign.exception.SnsShareFeedFailException;
 import com.wanted.feed.feed.domain.Feed;
 import com.wanted.feed.feed.domain.FeedRepository;
 import com.wanted.feed.feed.domain.Share;

--- a/src/test/java/com/wanted/feed/feign/SnsClientTest.java
+++ b/src/test/java/com/wanted/feed/feign/SnsClientTest.java
@@ -4,7 +4,7 @@ package com.wanted.feed.feign;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.wanted.feed.exception.client.SnsContentIdNotNullException;
+import com.wanted.feed.feign.exception.SnsContentIdNotNullException;
 import com.wanted.feed.feign.dto.response.ClientShareResponseDto;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/wanted/feed/feign/SnsTypeTest.java
+++ b/src/test/java/com/wanted/feed/feign/SnsTypeTest.java
@@ -3,7 +3,7 @@ package com.wanted.feed.feign;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.wanted.feed.exception.client.SnsNotSupportException;
+import com.wanted.feed.feign.exception.SnsNotSupportException;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/wanted/feed/feign/handler/SnsClientHandlerTest.java
+++ b/src/test/java/com/wanted/feed/feign/handler/SnsClientHandlerTest.java
@@ -2,7 +2,7 @@ package com.wanted.feed.feign.handler;
 
 import static org.assertj.core.api.Assertions.*;
 
-import com.wanted.feed.exception.client.SnsNotSupportException;
+import com.wanted.feed.feign.exception.SnsNotSupportException;
 import com.wanted.feed.feed.domain.Feed;
 import com.wanted.feed.feign.SnsClient;
 import com.wanted.feed.feign.TwitterClient;


### PR DESCRIPTION
## 💻 작업 내역 
### ✔️ 예외 패키지 이동 320ead6628335ee8d2c969fc975d76530ed85737

1. 공통된 exception 패키지를 common 패키지 하위로 이동
2. 각 도메인 별로 있는 exception은 그대로 둔다.
3. 단 exception 아래에 있는 feed.like 랑 client 패키지의 경우 각 도메인 레벨 아래 있는 exception패키지 아래로 옮김

## 🔎 PR 특이 사항
리팩토링 과정에서 import 되는 부분이 많이 달라졌습니다. 따라서 유의하여 코드 작성 바랍니다. 
320ead6628335ee8d2c969fc975d76530ed85737 

@min050410 @hsjkdss228 